### PR TITLE
detect ci environment

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func GetClient(ci bool) (*kubernetes.Clientset, error) {
+	user, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	var configDir, server string
+	if ci {
+		configDir = ".shipyard"
+		server = "127.0.0.1"
+	} else {
+		configDir = ".minikube"
+		out, err := exec.Command("minikube", "ip").Output()
+		if err != nil {
+			return nil, err
+		}
+		minikubeIP := strings.TrimSpace(string(out))
+		server = string(minikubeIP)
+	}
+
+	crtFile := filepath.Join(user.HomeDir, configDir, "client.crt")
+	keyFile := filepath.Join(user.HomeDir, configDir, "client.key")
+	caFile := filepath.Join(user.HomeDir, configDir, "ca.crt")
+
+	config := &rest.Config{
+		Host: "https://" + server + ":8443",
+		TLSClientConfig: rest.TLSClientConfig{
+			CertFile: crtFile,
+			KeyFile:  keyFile,
+			CAFile:   caFile,
+		},
+	}
+
+	// create the clientset
+	return kubernetes.NewForConfig(config)
+}

--- a/pkg/shipyard/shipyard_test.go
+++ b/pkg/shipyard/shipyard_test.go
@@ -2,50 +2,37 @@ package shipyard_test
 
 import (
 	"context"
-	"crypto/tls"
-	"net/http"
-	"os/user"
-	"path/filepath"
+	"os"
 	"testing"
 
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/microstorage/storagetest"
 	"github.com/giantswarm/shipyard/pkg/awsminikube"
 	"github.com/giantswarm/shipyard/pkg/files"
+	"github.com/giantswarm/shipyard/pkg/k8s"
 	"github.com/giantswarm/shipyard/pkg/names"
 	"github.com/giantswarm/shipyard/pkg/shipyard"
 	"github.com/giantswarm/tprstorage"
 	"github.com/spf13/afero"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestShipyard(t *testing.T) {
+	var ci bool
 	logger := microloggertest.New()
-	engine := awsminikube.New("shipyard-test-"+names.Rand(7), awsminikube.DefaultConfig(), logger)
-	filesHandler := files.NewHandler(afero.NewOsFs())
-	sy := shipyard.New(logger, engine, filesHandler)
+	if os.Getenv("CIRCLECI") == "true" {
+		ci = true
+		engine := awsminikube.New("shipyard-test-"+names.Rand(7), awsminikube.DefaultConfig(), logger)
+		filesHandler := files.NewHandler(afero.NewOsFs())
+		sy := shipyard.New(logger, engine, filesHandler)
 
-	if err := sy.Start(); err != nil {
-		t.Fatalf("Could not start shipyard: %v", err)
+		if err := sy.Start(); err != nil {
+			t.Fatalf("Could not start shipyard: %v", err)
+		}
+		defer sy.Stop()
 	}
-	defer sy.Stop()
-
-	t.Run("API up", func(t *testing.T) {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client := &http.Client{Transport: tr}
-		resp, err := client.Get("https://127.0.0.1:8443")
-		if err != nil {
-			t.Fatalf("could not access api, %v", err)
-		}
-		resp.Body.Close()
-	})
 
 	t.Run("tpr storage example", func(t *testing.T) {
-		k8sClient, err := getK8sClient()
+		k8sClient, err := k8s.GetClient(ci)
 		if err != nil {
 			t.Fatalf("error creating K8s client: %#v", err)
 		}
@@ -70,19 +57,4 @@ func TestShipyard(t *testing.T) {
 
 		storagetest.Test(t, storage)
 	})
-}
-
-func getK8sClient() (*kubernetes.Clientset, error) {
-	user, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(user.HomeDir, ".shipyard", "config"))
-	if err != nil {
-		return nil, err
-	}
-
-	// create the clientset
-	return kubernetes.NewForConfig(config)
 }


### PR DESCRIPTION
Example of how to use environment variables to detect the environment the build runs on and use either shipyard or minikube for testing. This way the same tests can be run with minikube locally and with shipyard in CI.