### PR TITLE
save files to current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.shipyard.yaml
+.shipyard/

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ can create a shipyard instance with:
 ```bash
 $ shipyard
 ```
-After setting `KUBECONFIG` to `$HOME/.shipyard/config`  kubectl access the remote cluster:
+After setting `KUBECONFIG` to `./.shipyard/config`  kubectl access the remote cluster:
 
 ```bash
-$ export KUBECONFIG=$HOME/.shipyard/config
+$ export KUBECONFIG=./.shipyard/config
 $ kubectl get cs
 NAME                 STATUS    MESSAGE              ERROR
 scheduler            Healthy   ok

--- a/pkg/awsminikube/awsminikube.go
+++ b/pkg/awsminikube/awsminikube.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -323,17 +323,14 @@ func (e *Engine) getAssets(res *result) (*result, error) {
 	if err != nil {
 		return nil, err
 	}
-	user, err := user.Current()
+	dir, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
+	baseDir := filepath.Join(dir, ".shipyard")
 	kubeconfigContent = strings.Replace(kubeconfigContent,
-		"/home/ubuntu",
-		user.HomeDir,
-		-1)
-	kubeconfigContent = strings.Replace(kubeconfigContent,
-		"minikube",
-		"shipyard",
+		"/home/ubuntu/.minikube",
+		baseDir,
 		-1)
 	res.kubeconfigContent = kubeconfigContent
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -3,12 +3,15 @@ package files
 import (
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/giantswarm/shipyard/pkg/engine"
 	"github.com/spf13/afero"
 	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	configFile = "shipyard.yaml"
 )
 
 type Handler struct {
@@ -39,12 +42,10 @@ func (h *Handler) Write(res *engine.Result) error {
 }
 
 func (h *Handler) writeCerts(res *engine.Result) error {
-	user, err := user.Current()
+	baseDir, err := GetBaseDir()
 	if err != nil {
 		return err
 	}
-
-	baseDir := filepath.Join(user.HomeDir, ".shipyard")
 	if err := h.fs.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
@@ -74,12 +75,10 @@ func (h *Handler) writeCerts(res *engine.Result) error {
 }
 
 func (h *Handler) writeKubeConfig(res *engine.Result) error {
-	user, err := user.Current()
+	baseDir, err := GetBaseDir()
 	if err != nil {
 		return err
 	}
-
-	baseDir := filepath.Join(user.HomeDir, ".shipyard")
 	if err := h.fs.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
@@ -94,7 +93,7 @@ func (h *Handler) writeKubeConfig(res *engine.Result) error {
 }
 
 func (h *Handler) writeShipyardCfg(res *engine.Result) error {
-	dir, err := os.Getwd()
+	dir, err := GetBaseDir()
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,7 @@ func (h *Handler) writeShipyardCfg(res *engine.Result) error {
 		return err
 	}
 	if err := ioutil.WriteFile(
-		filepath.Join(dir, ".shipyard.yaml"),
+		filepath.Join(dir, configFile),
 		[]byte(content),
 		0644); err != nil {
 		return err
@@ -114,12 +113,12 @@ func (h *Handler) writeShipyardCfg(res *engine.Result) error {
 }
 
 func (h *Handler) ReadShipyardCfg() (*engine.Result, error) {
-	dir, err := os.Getwd()
+	dir, err := GetBaseDir()
 	if err != nil {
 		return nil, err
 	}
 
-	content, err := ioutil.ReadFile(filepath.Join(dir, ".shipyard.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dir, configFile))
 	if err != nil {
 		return nil, err
 	}
@@ -130,4 +129,13 @@ func (h *Handler) ReadShipyardCfg() (*engine.Result, error) {
 		return nil, err
 	}
 	return e, nil
+}
+
+func GetBaseDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, ".shipyard"), nil
 }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/giantswarm/shipyard/pkg/files"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -18,10 +19,13 @@ func GetClient(ci bool) (*kubernetes.Clientset, error) {
 
 	var configDir, server string
 	if ci {
-		configDir = ".shipyard"
+		configDir, err = files.GetBaseDir()
+		if err != nil {
+			return nil, err
+		}
 		server = "127.0.0.1"
 	} else {
-		configDir = ".minikube"
+		configDir = filepath.Join(user.HomeDir, ".minikube")
 		out, err := exec.Command("minikube", "ip").Output()
 		if err != nil {
 			return nil, err
@@ -30,9 +34,9 @@ func GetClient(ci bool) (*kubernetes.Clientset, error) {
 		server = string(minikubeIP)
 	}
 
-	crtFile := filepath.Join(user.HomeDir, configDir, "client.crt")
-	keyFile := filepath.Join(user.HomeDir, configDir, "client.key")
-	caFile := filepath.Join(user.HomeDir, configDir, "ca.crt")
+	crtFile := filepath.Join(configDir, "client.crt")
+	keyFile := filepath.Join(configDir, "client.key")
+	caFile := filepath.Join(configDir, "ca.crt")
 
 	config := &rest.Config{
 		Host: "https://" + server + ":8443",


### PR DESCRIPTION
I was getting errors using shipyard on an alpine container `user: Current not implemented on linux/amd64`, caused by `user.Current` requiring cgo https://github.com/golang/go/issues/14625. With these changes all the files are saved in the current directory.