### PR TITLE
added forward-port action

### DIFF
--- a/cmd/shipyard/main.go
+++ b/cmd/shipyard/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	action = flag.String("action", "start", "action to accomplish, valid values 'start' and 'stop'")
+	action = flag.String("action", "start", "action to accomplish, valid values 'start', 'stop' and 'forward-port'")
 	name   = flag.String("name", "", "build name, if none is provided a random one will be generated")
 )
 
@@ -46,6 +46,11 @@ func main() {
 	case "stop":
 		if err := sy.Stop(); err != nil {
 			logger.Log("error", fmt.Sprintf("Could not stop shipyard: %v", err))
+			os.Exit(1)
+		}
+	case "forward-port":
+		if err := sy.ForwardPort(); err != nil {
+			logger.Log("error", fmt.Sprintf("Could not forward-port: %v", err))
 			os.Exit(1)
 		}
 	default:

--- a/pkg/awsminikube/awsminikube.go
+++ b/pkg/awsminikube/awsminikube.go
@@ -156,6 +156,18 @@ func (e *Engine) TearDown(res *engine.Result) (*engine.Result, error) {
 	return e.executeStages(e.result, stages)
 }
 
+func (e *Engine) ForwardPort(res *engine.Result) (*engine.Result, error) {
+	e.name = res.ClusterID
+	e.result = &result{
+		instanceIP:        res.InstanceIP,
+		privateKeyContent: res.PrivateKeyContent,
+	}
+	stages := []stage{
+		e.forwardPort,
+	}
+	return e.executeStages(e.result, stages)
+}
+
 func (e *Engine) executeStages(res *result, stages []stage) (*engine.Result, error) {
 	var err error
 	for _, s := range stages {
@@ -172,6 +184,7 @@ func (e *Engine) executeStages(res *result, stages []stage) (*engine.Result, err
 		ClientKeyContent:  res.clientKeyContent,
 		KubeconfigContent: res.kubeconfigContent,
 		InstanceIP:        res.instanceIP,
+		PrivateKeyContent: res.privateKeyContent,
 	}, nil
 }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -8,10 +8,12 @@ type Result struct {
 	ClientCrtContent  string `yaml:"-"`
 	ClientKeyContent  string `yaml:"-"`
 	KubeconfigContent string `yaml:"-"`
+	PrivateKeyContent string `yaml:"-"`
 }
 
 // Engine abstracts the required functionality of a test cluster
 type Engine interface {
 	SetUp() (*Result, error)
 	TearDown(res *Result) (*Result, error)
+	ForwardPort(res *Result) (*Result, error)
 }

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -88,10 +88,11 @@ func (h *Handler) writeKubeConfig(res *engine.Result) error {
 	if err := h.fs.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(
+	err = ioutil.WriteFile(
 		filepath.Join(baseDir, "config"),
 		[]byte(res.KubeconfigContent),
-		0644); err != nil {
+		0644)
+	if err != nil {
 		return err
 	}
 
@@ -106,10 +107,11 @@ func (h *Handler) writePrivateKey(res *engine.Result) error {
 	if err := h.fs.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(
+	err = ioutil.WriteFile(
 		filepath.Join(baseDir, privateKeyFile),
 		[]byte(res.PrivateKeyContent),
-		0644); err != nil {
+		0644)
+	if err != nil {
 		return err
 	}
 
@@ -126,10 +128,11 @@ func (h *Handler) writeShipyardCfg(res *engine.Result) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(
+	err = ioutil.WriteFile(
 		filepath.Join(dir, configFile),
 		[]byte(content),
-		0644); err != nil {
+		0644)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/shipyard/shipyard.go
+++ b/pkg/shipyard/shipyard.go
@@ -42,3 +42,14 @@ func (sy *Shipyard) Stop() error {
 	_, err = sy.engine.TearDown(initialResult)
 	return err
 }
+
+// ForwardPort sets up the ssh port forwarding.
+func (sy *Shipyard) ForwardPort() error {
+	sy.logger.Log("info", "Forwarding port...")
+	initialResult, err := sy.filesHandler.ReadShipyardCfg()
+	if err != nil {
+		return err
+	}
+	_, err = sy.engine.ForwardPort(initialResult)
+	return err
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1853

This will allow us to reuse the same shipyard deployment in different containers, just having the status files in place.